### PR TITLE
Flask upgrade

### DIFF
--- a/ga4gh/server/frontend.py
+++ b/ga4gh/server/frontend.py
@@ -16,7 +16,8 @@ import functools
 import json
 
 import flask
-import flask.ext.cors as cors
+from flask_cors import cross_origin, CORS as cors
+# import flask.ext.cors as cors
 # from flask.ext.oidc import OpenIDConnect
 from flask import jsonify, render_template, request  # Flask
 import humanize
@@ -386,7 +387,7 @@ def configure(configFile=None, baseConfig="ProductionConfig",
         app.config["FILE_HANDLE_CACHE_MAX_SIZE"])
     # Setup CORS
     try:
-        cors.CORS(app, allow_headers='Content-Type')
+        cors(app, allow_headers='Content-Type')
     except AssertionError:
         pass
     app.serverStatus = ServerStatus()
@@ -1199,7 +1200,7 @@ def callback_handling():
 
 @app.route("/logout")
 @requires_auth
-@cors.cross_origin(headers=['Content-Type', 'Authorization'])
+@cross_origin(headers=['Content-Type', 'Authorization'])
 def logout():
     key = flask.session['auth0_key']
     auth.logout(app.cache)

--- a/ga4gh/server/frontend.py
+++ b/ga4gh/server/frontend.py
@@ -16,7 +16,7 @@ import functools
 import json
 
 import flask
-from flask_cors import cross_origin, CORS as cors
+from flask_cors import cross_origin, CORS
 # import flask.ext.cors as cors
 # from flask.ext.oidc import OpenIDConnect
 from flask import jsonify, render_template, request  # Flask
@@ -387,7 +387,7 @@ def configure(configFile=None, baseConfig="ProductionConfig",
         app.config["FILE_HANDLE_CACHE_MAX_SIZE"])
     # Setup CORS
     try:
-        cors(app, allow_headers='Content-Type')
+        CORS(app, allow_headers='Content-Type')
     except AssertionError:
         pass
     app.serverStatus = ServerStatus()

--- a/ga4gh/server/serverconfig.py
+++ b/ga4gh/server/serverconfig.py
@@ -156,12 +156,14 @@ class FlaskDefaultConfig(object):
     The default values for the Flask config.
     Only used in testing.
     """
-    APPLICATION_ROOT = "/"
+    APPLICATION_ROOT = '/'
     DEBUG = False
+    EXPLAIN_TEMPLATE_LOADING = True
     JSONIFY_PRETTYPRINT_REGULAR = True
     JSON_AS_ASCII = True
     JSON_SORT_KEYS = True
     LOGGER_NAME = 'ga4gh.frontend'
+    LOGGER_HANDLER_POLICY = None
     MAX_CONTENT_LENGTH = None
     MAX_COOKIE_SIZE = 4093
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(31)
@@ -177,6 +179,7 @@ class FlaskDefaultConfig(object):
     SESSION_COOKIE_PATH = None
     SESSION_COOKIE_SECURE = False
     SESSION_COOKIE_SAMESITE = None
+    SESSION_REFRESH_EACH_REQUEST = None
     TESTING = False
     TEMPLATES_AUTO_RELOAD = None
     TRAP_BAD_REQUEST_ERRORS = False

--- a/ga4gh/server/serverconfig.py
+++ b/ga4gh/server/serverconfig.py
@@ -156,13 +156,14 @@ class FlaskDefaultConfig(object):
     The default values for the Flask config.
     Only used in testing.
     """
-    APPLICATION_ROOT = None
+    APPLICATION_ROOT = "/"
     DEBUG = False
     JSONIFY_PRETTYPRINT_REGULAR = True
     JSON_AS_ASCII = True
     JSON_SORT_KEYS = True
     LOGGER_NAME = 'ga4gh.frontend'
     MAX_CONTENT_LENGTH = None
+    MAX_COOKIE_SIZE = 4093
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(31)
     PREFERRED_URL_SCHEME = 'http'
     PRESERVE_CONTEXT_ON_EXCEPTION = None
@@ -175,7 +176,9 @@ class FlaskDefaultConfig(object):
     SESSION_COOKIE_NAME = 'session'
     SESSION_COOKIE_PATH = None
     SESSION_COOKIE_SECURE = False
+    SESSION_COOKIE_SAMESITE = None
     TESTING = False
+    TEMPLATES_AUTO_RELOAD = None
     TRAP_BAD_REQUEST_ERRORS = False
     TRAP_HTTP_EXCEPTIONS = False
     USE_X_SENDFILE = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ga4gh-common==0.0.7
 ga4gh-schemas
 ga4gh-client
 
-Werkzeug==0.11.5
+Werkzeug==0.14.1
 MarkupSafe==0.23
 itsdangerous==0.24
 six==1.10.0
@@ -33,7 +33,7 @@ enum34==1.1.2
 ipaddress==1.0.16
 cffi==1.5.2
 pycparser==2.14
-Jinja2==2.7.3
+Jinja2==2.10
 future==0.15.2
 pyjwkest==1.4.0
 PyJWT==1.4.2
@@ -45,8 +45,8 @@ peewee==2.8.5
 
 # Flask must come after all other requirements that have "flask" as a
 # prefix due to a setuptools bug.
-Flask-Cors==2.0.1
-Flask==0.10.1
+Flask-Cors==3.0.6
+Flask==1.0.2
 protobuf==3.3.0
 humanize==0.5.1
 pysam==0.9.0

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -336,10 +336,9 @@ class TestFrontend(unittest.TestCase):
         self.verifySearchRouting('/variantsets/search', True)
         self.verifySearchRouting('/variants/search', False)
 
-    @unittest.skip("Disabled for now, pending investigations")
     def testRouteIndex(self):
         path = "/"
-        response = self.app.options(path)
+        response = self.app.get(path)
         self.assertEqual(200, response.status_code)
         self.assertEqual("text/html", response.mimetype)
         self.assertGreater(len(response.data), 0)

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -336,9 +336,10 @@ class TestFrontend(unittest.TestCase):
         self.verifySearchRouting('/variantsets/search', True)
         self.verifySearchRouting('/variants/search', False)
 
+    @unittest.skip("Disabled for now, pending investigations")
     def testRouteIndex(self):
         path = "/"
-        response = self.app.get(path)
+        response = self.app.options(path)
         self.assertEqual(200, response.status_code)
         self.assertEqual("text/html", response.mimetype)
         self.assertGreater(len(response.data), 0)


### PR DESCRIPTION
Since the older version of Flask exposed some security vulnerabilities, we updated the Flask.

Since Flask depends on Werkzeug and Jinja2, those two packages got updated as well.

Note: the `app` below refers exclusively to `app = flask.Flask(__name__)` as defined in `frontend.py`

The actual code that got updated include:
1. In Flask 1.0.2, several attributes of the `app` got removed, including `LOGGER_NAME` . A KeyError was raised when the older version of `Flask-CORS` tried to reference this key. Thus, `Flask-CORS` was updated to resolve this problem.

2. In Flask 1.0, `flask.ext.package` no longer functions. Therefore the way to import `Flask-CORS` is different. The way of using and `cors` and `cross-origin` were subsequently changed. However, since these packages don't seem to get used anywhere (oicr as a whole), we might consider deleting them in future.

3. A number of new keys of the `app` were added into `FlaskDefaultConfig`. We ran into 500 error for tests that do `app.get('/')`, and those problems were resolved after we added `EXPLAIN_TEMPLATE_LOADING`. It seems like missing certain keys would cause things to fail miserably. It's also worth noting that, `LOGGER_NAME` no longer exists in Flask 1.0, but it wasn't removed in this PR. Let me know what you think.