### PR TITLE
add sample analysis into dashboard

### DIFF
--- a/ga4gh/server/static/main.js
+++ b/ga4gh/server/static/main.js
@@ -66,7 +66,7 @@ $("a[href='#gene_search']").on('shown.bs.tab', function(e) {
 $("a[href='#sample_analysis']").on('shown.bs.tab', function(e) {
     activeTab = e.target;
 
-    var tableIds = ["sample_analysis1", "sample_analysis2", "sample_analysis3", "sample_analysis4", "sample_analysis5", "sample_analysis6"];
+    var tableIds = ["extractions", "alignments", "sequencing", "variantcalling", "fusiondetection", "expressionanalysis"];
 
     initialize();
 
@@ -85,12 +85,10 @@ $("a[href='#sample_analysis']").on('shown.bs.tab', function(e) {
 
     function caller(){
         var request = document.getElementById("sampleSelect").value;
-        xhrInitiator("extractions", "sample_analysis1", request);
-        xhrInitiator("alignments", "sample_analysis2", request);
-        xhrInitiator("sequencing", "sample_analysis3", request);
-        xhrInitiator("variantcalling", "sample_analysis4", request);
-        xhrInitiator("fusiondetection", "sample_analysis5", request);
-        xhrInitiator("expressionanalysis", "sample_analysis6", request);
+
+        for (let i = 0; i < tableIds.length; i++) {
+            xhrInitiator(tableIds[i], tableIds[i], request)
+        }
     }
 
     // Initiates XHR calls to different endpoints

--- a/ga4gh/server/templates/spa.html
+++ b/ga4gh/server/templates/spa.html
@@ -160,12 +160,12 @@
                <button id="sampleSearch" class="btn btn-primary" name="submit">Submit</button>
          </div>
          <div class="container-fluid row" style="margin-top: 50px">
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis1"></div>
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis2"></div>
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis3"></div>
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis4"></div>
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis5"></div>
-               <div class="col-sm-2 ag-theme-balham" id="sample_analysis6"></div>
+               <div class="col-sm-2 ag-theme-balham" id="extractions"></div>
+               <div class="col-sm-2 ag-theme-balham" id="alignments"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sequencing"></div>
+               <div class="col-sm-2 ag-theme-balham" id="variantcalling"></div>
+               <div class="col-sm-2 ag-theme-balham" id="fusiondetection"></div>
+               <div class="col-sm-2 ag-theme-balham" id="expressionanalysis"></div>
          </div>
       </div>
    </div>

--- a/ga4gh/server/templates/spa.html
+++ b/ga4gh/server/templates/spa.html
@@ -13,6 +13,10 @@
       <script src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
       <script type="text/javascript" src="https://www.distributedgenomics.ca/static/igv-2.0.0-rc3.js"></script>
       <link type="text/css" rel="stylesheet" href="{{prepend_path}}/static/dashboard.css">
+      <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css">
+      <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css">
+
    </head>
    <!-- A grey horizontal navbar that becomes vertical on small screens -->
    <nav class="navbar navbar-expand-sm bg-light">
@@ -26,6 +30,9 @@
          </li>
          <li>
             <a class="nav-link" data-toggle="tab" href="#candig_patients">Patient overview</a>
+         </li>
+         <li>
+            <a class="nav-link" data-toggle="tab" href="#sample_analysis">Sample Analysis</a>
          </li>
          <li>
             <a class="nav-link" onclick="logout()" href="javascript:void(0)">Log out</a>
@@ -145,6 +152,20 @@
                   <table id="patientTable" class="table table-striped table-bordered nowrap"></table>
                </div>
             </div>
+         </div>
+      </div>
+      <div id="sample_analysis" class="tab-pane fade">
+         <div class="container row" style="margin-top: 50px">
+               <select class="form-control" id="sampleSelect" style="width: 30%; margin-left: 60%; margin-right: 10px;"></select>
+               <button id="sampleSearch" class="btn btn-primary" name="submit">Submit</button>
+         </div>
+         <div class="container-fluid row" style="margin-top: 50px">
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis1"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis2"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis3"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis4"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis5"></div>
+               <div class="col-sm-2 ag-theme-balham" id="sample_analysis6"></div>
          </div>
       </div>
    </div>


### PR DESCRIPTION
New additions:
1. Sample analysis was added onto the dashboard.
2. A global helper `warningBuilder` was added to eliminate repetitive code used across tabs.
3. Ag-grid library was added and is being used in the `Sample Analysis` tab.

Bug fixes:
1, When gene search is performed multiple times, the `select` for `readGroupSets` keeps appending new `options`.