### PR TITLE
various fix on dashboard and unused print in backend.py

### DIFF
--- a/ga4gh/server/backend.py
+++ b/ga4gh/server/backend.py
@@ -663,7 +663,6 @@ class Backend(object):
         tier = self.getUserAccessTier(dataset, access_map)
         results = []
         for obj in dataset.getSequencings():
-            print("looping over sequencings")
             qualified = self.comparisonGenerator(obj, request)
 
             if qualified:

--- a/ga4gh/server/static/main.js
+++ b/ga4gh/server/static/main.js
@@ -165,7 +165,7 @@ $("a[href='#sample_analysis']").on('shown.bs.tab', function(e) {
 
             for (var j = 0; j < columnDefs.length; j++) {
                 var tempItem = {};
-                tempItem["field"] = columnDefs[j];
+                tempItem["field"] = columnDefs[j].replace(/([a-z])([A-Z])/g, '$1 $2');
                 tempItem["value"] = dataset[k][columnDefs[j]];
                 newDataset.push(tempItem);
             }
@@ -655,7 +655,6 @@ $("a[href='#candig_patients']").on('shown.bs.tab', function(e) {
 
             $(document).ready(function() {
                 $('#mytable').DataTable({
-                    "scrollX": true,
                     initComplete: function() {
                         this.api().columns().every(function() {
                             var column = this;

--- a/ga4gh/server/templates/spa.html
+++ b/ga4gh/server/templates/spa.html
@@ -156,8 +156,8 @@
                   </div>
                </div>
                <div class="col-sm-9">
-                  <table id="mytable" class="table table-striped table-bordered nowrap hover"></table>
-                  <table id="patientTable" class="table table-striped table-bordered nowrap"></table>
+                  <div style="overflow: scroll"><table id="mytable" class="table table-striped table-bordered nowrap hover"></table></div>
+                  <div style="overflow: scroll"><table id="patientTable" class="table table-striped table-bordered nowrap"></table></div>
                </div>
             </div>
          </div>


### PR DESCRIPTION
This PR solves the issues as mentioned in https://github.com/CanDIG/ga4gh-server/issues/49

Bugs:
1. The native css `overflow: scroll` is used instead of the `scrollX` that comes with the dataTable, it solves the problem when the table becomes misaligned when zoomed out.
2. The sample analysis table's `column names` as shown in the first column have spaces added before a capitalized letter. This increased the readability.

MISC:
1. An unnecessary `print` statement is deleted from `backend.py`.