### PR TITLE
Dashboard update

### DIFF
--- a/ga4gh/server/static/dashboard.css
+++ b/ga4gh/server/static/dashboard.css
@@ -168,3 +168,7 @@
 #mytable {
     cursor: pointer;
 }
+
+#drugScatter .highcharts-legend {
+    display: none
+}

--- a/ga4gh/server/static/main.js
+++ b/ga4gh/server/static/main.js
@@ -539,17 +539,18 @@ $("a[href='#candig']").on('shown.bs.tab', function(e) {
 
     // Draw the drug scatter plot
     function drugScatter(cancerTypeWithDrug, cancerType) {
-        let testArray = Object.keys(cancerTypeWithDrug[cancerType])
-        let scatterArray = []
+        // list of drugs used in the current cancer type
+        let listOfDrugs = Object.keys(cancerTypeWithDrug[cancerType])
+        let listOfDrugsWithLength = []
 
-        for (var i = 0; i < testArray.length; i++) {
+        for (var i = 0; i < listOfDrugs.length; i++) {
             let temp;
-            for (var j = 0; j < cancerTypeWithDrug[cancerType][testArray[i]].length; j++) {
+            for (var j = 0; j < cancerTypeWithDrug[cancerType][listOfDrugs[i]].length; j++) {
                 temp = []
                 temp.push(i)
-                temp.push(cancerTypeWithDrug[cancerType][testArray[i]][j])
+                temp.push(cancerTypeWithDrug[cancerType][listOfDrugs[i]][j])
 
-                scatterArray.push(temp)
+                listOfDrugsWithLength.push(temp)
             }
         }
 
@@ -566,7 +567,7 @@ $("a[href='#candig']").on('shown.bs.tab', function(e) {
                 enabled: false
             },
             xAxis: {
-                categories: testArray
+                categories: listOfDrugs
             },
             yAxis: {
                 title: {
@@ -603,7 +604,7 @@ $("a[href='#candig']").on('shown.bs.tab', function(e) {
             series: [{
                 name: 'Drugs',
                 color: 'rgba(223, 83, 83, .75)',
-                data: scatterArray
+                data: listOfDrugsWithLength
 
             }]
         });

--- a/ga4gh/server/templates/spa.html
+++ b/ga4gh/server/templates/spa.html
@@ -111,6 +111,13 @@
                         </div>
                      </div>
                   </div>
+                   <div class="col-sm-12">
+                     <div class="card" style="border:solid; padding: 1rem; height: 30rem; margin-top: 50px">
+                        <div class="card-body">
+                           <div id="drugScatter" style="min-width: 310px; height: 400px; auto;"></div>
+                        </div>
+                     </div>
+                  </div>
                </div>
             </div>
          </div>


### PR DESCRIPTION
1. Add a new scatter plot that displays the frequency and duration and drugs used for selected cancer types, as requested in https://github.com/CanDIG/ga4gh-server/issues/52. The underlying logic of calculation was also changed, since the original way was very unreliable.

2. Add a "zoom" option for the timeline graph.