### PR TITLE
type check added during aggregation to check for list values

### DIFF
--- a/ga4gh/server/backend.py
+++ b/ga4gh/server/backend.py
@@ -498,6 +498,11 @@ class Backend(object):
                     if k in field:
                         if k not in field_value_counts:
                             field_value_counts[k] = {}
+
+                        if type(v) == list:
+                            v.sort()
+                            v = ','.join(v)
+
                         if v not in field_value_counts[k]:
                             field_value_counts[k][v] = 1
                         else:


### PR DESCRIPTION
Bug fix: list values in results are now sorted and string concatenated when forming aggregation keys to allow for aggregating on some fields that were previously giving a 500 (e.g. alternateBases)  